### PR TITLE
Shoring up DLLFILES approach

### DIFF
--- a/generate_aliases.py
+++ b/generate_aliases.py
@@ -22,7 +22,7 @@ def tokenize(path_to_REFPROP_lib_h, path_to_FORTRAN):
         for line in open(os.path.join(path_to_FORTRAN,"PASS_FTN.FOR"), 'r').readlines():
             PASS_CMN_tokens += re.findall(a, line)
     except:
-	for line in open(os.path.join(path_to_FORTRAN,"DLLFILES","PASS_FTN.FOR"), 'r').readlines():
+        for line in open(os.path.join(path_to_FORTRAN,"DLLFILES","PASS_FTN.FOR"), 'r').readlines():
             PASS_CMN_tokens += re.findall(a, line)
 
     with open(path_to_REFPROP_lib_h, 'r') as fp:


### PR DESCRIPTION
This avoids an error thrown from the Python script, but still fails in the final build phase (on Ubuntu):

```
$ cmake --build .
Scanning dependencies of target REFPROP_H
make[2]: *** No rule to make target '.../REFPROP/FORTRAN/PASS_FTN.FOR', needed by 'REFPROP.h.stamp'.  Stop.
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/REFPROP_H.dir/all' failed
make[1]: *** [CMakeFiles/REFPROP_H.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2
```