### PR TITLE
avoid `OSX_STATIC_LINK` from breaking `MINGW`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
          DESTINATION .)
     message(STATUS "Copied libquadmath.a here.")
 
-    if (REFPROP_OSX_STATIC_LINK)
+    if (REFPROP_OSX_STATIC_LINK OR MINGW)
 
       # Now we construct the flags to be passed to linker
       set(REFPROP_LINK_FLAGS "${REFPROP_LINK_FLAGS} -static -static-libgfortran -static-libgcc ")


### PR DESCRIPTION
I appreciate the addition of `REFPROP_OSX_STATIC_LINK` in https://github.com/usnistgov/REFPROP-cmake/commit/65cff2519263a113bcc8b99adf52b5cc388f58cb as I also use an M1, but seems like it should be decoupled from affecting the `MINGW` installation.

Alternative could be to highlight the `REFPROP_OSX_STATIC_LINK` flag within the `MINGW` instructions, but that seems inelegant.