### PR TITLE
Add MINGW static flag + documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,10 +51,15 @@ SET (REFPROP_NO_PYTHON
   CACHE BOOL
   "Disable all use of Python")
 
-SET (REFPROP_STATIC_LINK
+SET (REFPROP_OSX_STATIC_LINK
   FALSE
   CACHE BOOL
-  "Statically link the standard libraries for OSX or MINGW builds")
+  "Statically link the standard libraries for OSX")
+
+SET (REFPROP_MINGW_STATIC_LINK
+  FALSE
+  CACHE BOOL
+  "Statically link the standard libraries for MINGW builds")
 
 
 get_filename_component(REFPROP_FORTRAN_ABS_PATH "${REFPROP_FORTRAN_PATH}"
@@ -190,7 +195,7 @@ if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
          DESTINATION .)
     message(STATUS "Copied libquadmath.a here.")
 
-    if (REFPROP_STATIC_LINK)
+    if (REFPROP_OSX_STATIC_LINK OR REFPROP_MINGW_STATIC_FLAG)
 
       # Now we construct the flags to be passed to linker
       set(REFPROP_LINK_FLAGS "${REFPROP_LINK_FLAGS} -static -static-libgfortran -static-libgcc ")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,10 +51,10 @@ SET (REFPROP_NO_PYTHON
   CACHE BOOL
   "Disable all use of Python")
 
-SET (REFPROP_OSX_STATIC_LINK
+SET (REFPROP_STATIC_LINK
   FALSE
   CACHE BOOL
-  "Statically link the standard libraries")
+  "Statically link the standard libraries for OSX or MINGW builds")
 
 
 get_filename_component(REFPROP_FORTRAN_ABS_PATH "${REFPROP_FORTRAN_PATH}"
@@ -190,7 +190,7 @@ if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
          DESTINATION .)
     message(STATUS "Copied libquadmath.a here.")
 
-    if (REFPROP_OSX_STATIC_LINK)
+    if (REFPROP_STATIC_LINK)
 
       # Now we construct the flags to be passed to linker
       set(REFPROP_LINK_FLAGS "${REFPROP_LINK_FLAGS} -static -static-libgfortran -static-libgcc ")

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ The solution is to force cmake to use the brewed python:
 cmake .. -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE:FILEPATH=/usr/local/bin/python3
 ```
 
+* If you want statically-linked system libraries when compiling on OSX, to improve, but not guarantee, that a binary built on one machine will run on another, you can define:
+
+```
+cmake .. -DREFPROP_OSX_STATIC_LINK=ON
+```
+
 ## General Notes
 
 * Platforms other than windows (and sort of OSX) are CASE-SENSITIVE!  The folder ``fortran`` is not the same as ``FORTRAN``
@@ -92,10 +98,9 @@ cmake .. -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE:FILEPATH=/usr/local/bin/
 
 * If you want to make the Intel runtime dynamically linked into the shared library (this is necessary in order to load hundreds of copies of REFPROP in memory with the REFPROP-manager (see https://github.com/usnistgov/REFPROP-manager)), define the CMake flag ``-DREFPROP_DYNAMIC_RUNTIME=ON``.  The default is to statically link the runtime, which is the right answers for most users and use cases.
 
-* If you want statically-linked system libraries when compiling on OSX or with MINGW on Windows, to improve, but not guarantee, that a binary built on one machine will run on another, you can define:
-
+* If you want statically-linked system libraries when compiling with MINGW, to improve, but not guarantee, that a binary built on one machine will run on another, you can define:
 ```
-cmake .. -DREFPROP_STATIC_LINK=ON
+cmake .. -DREFPROP_MINGW_STATIC_LINK=ON
 ```
 
 ## Instructions for MINGW builds on windows

--- a/README.md
+++ b/README.md
@@ -58,12 +58,6 @@ The solution is to force cmake to use the brewed python:
 cmake .. -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE:FILEPATH=/usr/local/bin/python3
 ```
 
-* If you want statically-linked system libraries, to improve, but not guarantee, that a binary built on one machine will run on another, you can define:
-
-```
-cmake .. -DREFPROP_OSX_STATIC_LINK=ON
-```
-
 ## General Notes
 
 * Platforms other than windows (and sort of OSX) are CASE-SENSITIVE!  The folder ``fortran`` is not the same as ``FORTRAN``
@@ -97,6 +91,12 @@ cmake .. -DREFPROP_OSX_STATIC_LINK=ON
     ``cmake --build . --config Release``
 
 * If you want to make the Intel runtime dynamically linked into the shared library (this is necessary in order to load hundreds of copies of REFPROP in memory with the REFPROP-manager (see https://github.com/usnistgov/REFPROP-manager)), define the CMake flag ``-DREFPROP_DYNAMIC_RUNTIME=ON``.  The default is to statically link the runtime, which is the right answers for most users and use cases.
+
+* If you want statically-linked system libraries when compiling on OSX or with MINGW on Windows, to improve, but not guarantee, that a binary built on one machine will run on another, you can define:
+
+```
+cmake .. -DREFPROP_STATIC_LINK=ON
+```
 
 ## Instructions for MINGW builds on windows
 


### PR DESCRIPTION
Alternative to #76.

Might also make sense to put `General Notes` before `OSX Notes` but I don't know what the rationale for putting `OSX` first was.